### PR TITLE
54/two tier bp (#63)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ script:
     - docker exec ubuntu bash -c 'cd avatar2/ && python2 ./tests/gdb_memory_map_loader.py'
     - docker exec ubuntu bash -c 'cd avatar2/ && python3 ./tests/gdb_memory_map_loader.py'
 
-    - docker exec ubuntu bash -c 'cd avatar2/ && nosetests-2.7 --processes=-1 --process-timeout=20 ./tests/smoke/target_wait.py'
-    - docker exec ubuntu bash -c 'cd avatar2/ && nosetests-3.4 --processes=-1 --process-timeout=20 ./tests/smoke/target_wait.py'
+    - docker exec ubuntu bash -c 'cd avatar2/ && nosetests-2.7 --processes=-1 --process-timeout=40 ./tests/smoke/target_wait.py'
+    - docker exec ubuntu bash -c 'cd avatar2/ && nosetests-3.4 --processes=-1 --process-timeout=40 ./tests/smoke/target_wait.py'
 
     - docker exec ubuntu bash -c 'cd avatar2/ && AVATAR2_GDB_EXECUTABLE=gdb-multiarch AVATAR2_QEMU_EXECUTABLE=./targets/build/panda/panda/arm-softmmu/panda-system-arm nosetests-2.7 --processes=-1 --process-timeout=20 ./tests/smoke/54_sync_hooks.py'
     - docker exec ubuntu bash -c 'cd avatar2/ && AVATAR2_GDB_EXECUTABLE=gdb-multiarch AVATAR2_QEMU_EXECUTABLE=./targets/build/panda/panda/arm-softmmu/panda-system-arm nosetests-3.4 --processes=-1 --process-timeout=20 ./tests/smoke/54_sync_hooks.py'

--- a/avatar2/avatar2.py
+++ b/avatar2/avatar2.py
@@ -335,12 +335,26 @@ class Avatar(Thread):
     def _handle_breakpoint_hit_message(self, message):
         self.log.info("Breakpoint hit for Target: %s" % message.origin.name)
         self._handle_update_state_message(message)
+        # Breakpoints are two stages: SYNCING | STOPPED -> HandleBreakpoint -> STOPPED
+        # This makes sure that all handlers are complete before stopping and breaking wait()
+
+        def bp_end_sync_cb(avatar, message, *args, **kwargs):
+                avatar.watchmen.remove_watchman('BreakpointHit', w)
+                avatar.fast_queue.put(UpdateStateMessage(message.origin,
+                                                         TargetStates.STOPPED))
+
+        # We handle this via a watchmen added in here, so we are sure that this
+        # watchmen gets executed *at the end*
+        # Note: This can break if another breakpoint-hit callback inserts an
+        #       additional breakpointhit-watchmen (after).
+        w = self.watchmen.add('BreakpointHit', when='after',
+                              callback=bp_end_sync_cb)
+
 
     @watch('SyscallCatched')
     def _handle_syscall_catched_message(self, message):
         self.log.info("Syscall catched for Target: %s" % message.origin.name)
         self._handle_update_state_message(message)
-
 
 
     @watch('RemoteMemoryRead')

--- a/avatar2/message.py
+++ b/avatar2/message.py
@@ -19,7 +19,7 @@ class UpdateStateMessage(AvatarMessage):
 
 class BreakpointHitMessage(UpdateStateMessage):
     def __init__(self, origin, breakpoint_number, address):
-        super(BreakpointHitMessage, self).__init__(origin, TargetStates.STOPPED)
+        super(BreakpointHitMessage, self).__init__(origin, TargetStates.BREAKPOINT)
         self.breakpoint_number = breakpoint_number
         self.address = address
 

--- a/avatar2/targets/target.py
+++ b/avatar2/targets/target.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from sys import version_info
 from functools import wraps
 from threading import Event
@@ -96,6 +97,7 @@ class TargetStates(IntEnum):
     SYNCING = 0x10
     EXITED = 0x20
     NOT_RUNNING = INITIALIZED | STOPPED
+    BREAKPOINT = SYNCING | STOPPED
 
 class TargetRegs(object):
     def __init__(self, target, register_dict):
@@ -212,7 +214,6 @@ class Target(object):
         self.protocols = TargetProtocolStore()
 
         self.state = TargetStates.CREATED
-        self.processing_callbacks = Event()
 
         self.log = logging.getLogger('%s.targets.%s' % (avatar.log.name, self.name))
         log_file = logging.FileHandler('%s/%s.log' % (avatar.output_directory, self.name))
@@ -227,8 +228,7 @@ class Target(object):
         Returns the memory range as *printable* dictionary for the config
         """
 
-        ignore = ['state', 'status', 'regs', 'protocols', 'log', 'avatar',
-                  'processing_callbacks']
+        ignore = ['state', 'status', 'regs', 'protocols', 'log', 'avatar']
         ignored_types = (MethodType)
         expected_types = (str, bool, int, list) 
         if version_info < (3, 0): expected_types += (unicode, )
@@ -452,10 +452,16 @@ class Target(object):
 
     @watch('TargetWait')
     def wait(self, state=TargetStates.STOPPED|TargetStates.EXITED):
+
+        if state & TargetStates.SYNCING:
+            self.log.warn("Waiting on SYNCING-state - this could lead to races")
+
         while True:
-            self.processing_callbacks.wait(.1)
-            if self.state & state != 0:
+            if self.state & state != 0 and \
+               (state & TargetStates.SYNCING or \
+                self.state & TargetStates.SYNCING == 0):
                 break
+            time.sleep(.001) # send thread a ms to sleep to free resources
 
     def get_status(self):
         """

--- a/avatar2/watchmen.py
+++ b/avatar2/watchmen.py
@@ -73,15 +73,12 @@ def watch(watched_type):
             elif isinstance(self, Target):
                 avatar = self.avatar
                 cb_kwargs['watched_target'] = self
-                self.processing_callbacks.clear()
 
             avatar.watchmen.t(watched_type, BEFORE, *args, **cb_kwargs)
             ret = func(self, *args, **kwargs)
             cb_kwargs.update({'watched_return': ret})
             cb_ret = avatar.watchmen.t(watched_type, AFTER, *args, **cb_kwargs)
 
-            if isinstance(self, Target):
-                self.processing_callbacks.set()
             return ret if cb_ret is None else cb_ret
 
         return watchtrigger


### PR DESCRIPTION
* Make BreakpointHitMessage be two states

* Adjust synchronization to two tier breakpoint

* unroll changes of watchmen clear/set processing-callbacks Event

* Adjust wait to explicitly check if we are SYNCING

* Increase timeout for targetwait smoketest

The two-tiered breakpoint approach slows execution down, hence, we need
some more time.

Co-authored-by: Grant Hernandez <grant.h.hernandez@gmail.com>